### PR TITLE
Added xcpretty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ env:
 xcode_project: GLTableCollectionView.xcodeproj
 xcode_scheme: GLTableCollectionView
 before_install:
+    - brew update
+    - brew upgrade
+    - gem update
+    - gem install xcpretty
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test
+script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty
+script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty && exit ${PIPESTATUS[0]}

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_install:
     - brew upgrade
     - gem update
     - gem install xcpretty
+    - gem install xcpretty-travis-formatter
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty && exit ${PIPESTATUS[0]}
+script: xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty -f `xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
- Added [`xcpretty`](https://github.com/supermarin/xcpretty) formatting to Travis CI builds
- Added [`xcpretty-travis-formatter`](https://github.com/kattrali/xcpretty-travis-formatter) xcpretty's un-official extension
- Added `brew update`, `brew upgrade` and `gem update` in the `before_install:` section of the Travis CI